### PR TITLE
Add flag to clear output when interm data is recieved

### DIFF
--- a/overlay.html
+++ b/overlay.html
@@ -987,6 +987,10 @@
 					window.CAPTION_TTS.speak(data.interm, true);
 				}
 			} catch(e){ console.warn(e); }
+
+			if (urlParams.has("intermclear")) {
+				document.getElementById("output").innerHTML="";
+			}
 		} else if ("final" in data){
 		 
 			// Decide between built-in overlay TTS and external tts.rocks


### PR DESCRIPTION
Addresses #18

Adds a new URL parameter, `intermclear`, which wipes the `output` div whenever new `interm` data is added.

Doesn't touch the `final` code, so the text move to `div#output` is maintained, and making sure that TTS functionality still works.